### PR TITLE
Fix TypeError with TypedDate instead of Data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-- 1.9.3
-- 2.1.2
+- 2.2.0
+- 2.3.0
 script: bundle exec rake test
 notifications:
   webhooks:

--- a/ext/ies/ies.c
+++ b/ext/ies/ies.c
@@ -6,7 +6,7 @@ static EC_KEY *require_ec_key(VALUE self)
 {
     const EVP_PKEY *pkey;
     const EC_KEY *ec;
-    Data_Get_Struct(self, EVP_PKEY, pkey);
+    TypedData_Get_Struct(self, EVP_PKEY, RTYPEDDATA_TYPE(self), pkey);
     if (!pkey) {
 	rb_raise(rb_eRuntimeError, "PKEY wasn't initialized!");
     }


### PR DESCRIPTION
When using this library, TypeError will be occured. My environment is Ruby 2.3.

This is because the data type used in Ruby's C extension has been changed.　https://github.com/ruby/ruby/commit/163cb5b43de68cef7ae4fa053d710098399d1359

So I changed to use TypedData instead of Data.